### PR TITLE
MRC-470: tidy up package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
   - mrc-ide/context
-  - richfitz/seagull

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ Imports:
     progress (>= 1.1.1)
 Suggests:
     processx,
-    seagull,
     testthat
 RoxygenNote: 5.0.1
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     progress (>= 1.1.1)
 Suggests:
     processx,
+    storr,
     testthat
 RoxygenNote: 5.0.1
 Encoding: UTF-8

--- a/R/fifo_queue.R
+++ b/R/fifo_queue.R
@@ -1,143 +1,63 @@
-## This is something that might be better in its own package.
-##
-## Dealing with types here is hard, so for now I will assume that this
-## is going to be storing a set of *strings* (not objects, which could
-## be accessed based on the string).
-
-## Here, we might want to make this either "safe" or "unsafe"; use the
-## db access regardless.  But it would probably be better to have the
-## unsafe version use an in-memory queue (currently implemented
-## naively).
-
-## The different interfaces here could be dealt with by testing the
-## type of the database server (doing the _r one when it's NULL).  For
-## now leave this be.
-
-## * For environment based storage, no need to lock because there
-##   cannot be any contention.
-##
-## * For RDS based storage, use seagull to lock the database
-##
-## * For Redis, we can do everything atomically so it's really easy
-##
-## * For DBI based databases we need to do things atomically in a
-##   transaction, but it could be done.  Worth getting right because
-##   we'll be needing this at some point perhaps.
-fifo_seagull <- function(db, key, namespace, lockfile, timeout) {
-  loadNamespace("seagull")
-  force(db)
-  force(key)
-  force(namespace)
-  force(lockfile)
-  force(timeout)
-
-  read <- function() {
-    tryCatch(db$get(key, namespace),
-             KeyError = function(e) character(0))
-  }
-  write <- function(x) {
-    db$set(key, x, namespace)
-  }
-
-  push <- function(x) {
-    seagull::with_flock(lockfile, {
-      tot <- c(read(), x)
-      write(tot)
-      invisible(length(tot))
-    }, timeout = timeout)
-  }
-
-  pop <- function() {
-    seagull::with_flock(lockfile, {
-      queue <- read()
-      if (length(queue) > 0L) {
-        write(queue[-1L])
-        queue[[1]]
-      } else {
-        NULL
-      }
-    }, timeout = timeout)
-  }
-
-  drop <- function(x) {
-    seagull::with_flock(lockfile, {
-      queue <- read()
-      if (length(queue) > 0L) {
-        write(setdiff(queue, x))
-      }
-      invisible(x %in% queue)
-    }, timeout = timeout)
-  }
-
-  list(read = read,
-       push = push,
-       pop = pop,
-       drop = drop)
+fifo_thor <- function(path) {
+  R6_fifo_thor$new(path)
 }
 
 
-## fifo_redis <- function(con, key, timeout) {
-##   force(con)
-##   force(key)
-##   force(timeout)
+R6_fifo_thor <- R6::R6Class(
+  "fifo_thor",
+  cloneable = FALSE,
 
-##   read <- function() {
-##     vcapply(con$LRANGE(key, 0, -1), identity)
-##   }
-##   push <- function(x) {
-##     con$RPUSH(key, x)
-##   }
-##   pop <- function(x) {
-##     con$LPOP(key)
-##   }
-##   drop <- function(x) {
-##     ## This needs to be done in a LUA script.
-##     stop("not yet implemented")
-##   }
+  private = list(
+    mdb = NULL,
+    key = NULL,
+    split = function(x) {
+      strsplit(x %||% "", "\r", fixed = TRUE)[[1]]
+    },
 
-##   list(read = read,
-##        push = push,
-##        pop = pop,
-##        drop = drop)
-## }
+    join = function(a, b = NULL) {
+      paste(c(a, b), collapse = "\r")
+    }
+  ),
 
-## fifo_r <- function() {
-##   data <- character()
+  public = list(
+    initialize = function(path, key = "queue") {
+      loadNamespace("thor")
+      private$mdb <- thor::mdb_env(path)
+      private$key <- key
+    },
 
-##   read <- function() {
-##     data
-##   }
-##   push <- function(x) {
-##     data <<- c(data, x)
-##     invisible(length(data))
-##   }
-##   pop <- function(x) {
-##     ret <- data[[1L]]
-##     data <<- data[-1L]
-##     ret
-##   }
-##   drop <- function(x) {
-##     data <<- setdiff(data, x)
-##   }
+    read = function() {
+      private$split(private$mdb$get(private$key, FALSE))
+   },
 
-##   list(read = read,
-##        push = push,
-##        pop = pop,
-##        drop = drop)
-## }
+    push = function(x) {
+      private$mdb$with_transaction(function(txn) {
+        prev <- private$split(txn$get(private$key, FALSE))
+        txn$put(private$key, private$join(prev, x))
+        invisible(length(prev) + length(x))
+      }, write = TRUE)
+    },
 
-## TODO: I don't think that seagull is a good idea, necessarily.  It
-## would be nicer to use RSQLite here (which does support concurrency)
-## perhaps.
-##
-## It might be nice to think about a generalised distributed
-## queue here that could be backed by different packages:
-##
-## * R in memory (single process)
-## * seagull
-## * SQLite
-## * Redis
-##
-## these would all have different pros and cons and would help a
-## bunch.
-## stop("rethink the queue here")
+    pop = function() {
+      private$mdb$with_transaction(function(txn) {
+        queue <- private$split(txn$get(private$key, FALSE))
+        if (length(queue) > 0L) {
+          txn$put(private$key, private$join(queue[-1L]))
+          queue[[1L]]
+        } else {
+          NULL
+        }
+      }, write = TRUE)
+    },
+
+    drop = function(x) {
+      private$mdb$with_transaction(function(txn) {
+        queue <- private$split(txn$get(private$key, FALSE))
+        present <- x %in% queue
+        if (any(present)) {
+          txn$put(private$key, private$join(setdiff(queue, x)))
+        }
+        invisible(present)
+      }, write = TRUE)
+    }
+  ))

--- a/R/queue_local.R
+++ b/R/queue_local.R
@@ -34,10 +34,9 @@ R6_queue_local <- R6::R6Class(
     initialize = function(context_id, root, initialize, log) {
       super$initialize(context_id, root, initialize)
 
-      lockfile <- file.path(self$root$path, "lockfiles", self$context$id)
-      dir.create(dirname(lockfile), FALSE, TRUE)
-      self$fifo <- fifo_seagull(self$db, self$context$id, "queue_local",
-                                lockfile, self$timeout)
+      path_fifo <- file.path(self$root$path, "fifo", self$context$id)
+      dir.create(dirname(path_fifo), FALSE, TRUE)
+      self$fifo <- fifo_thor(path_fifo)
 
       if (isTRUE(log)) {
         self$log_path <- file.path(self$root$path, "logs")
@@ -102,9 +101,6 @@ R6_queue_local <- R6::R6Class(
       ## TODO: Until messaging is implemented, this will need to run
       ## until interrupted.  Messaging should be fairly easy to
       ## implement because we can just poll a key with exists().
-      ##
-      ## TODO: get a growing timeout in here too (abstract away the
-      ## one I have in seagull:R/util.R:retry()
       tryCatch(
         repeat {
           res <- self$run_next()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@
 
 environment:
   global:
+    R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
     USE_RTOOLS: true
 
 # Download script file from GitHub
@@ -18,6 +19,7 @@ install:
 
 build_script:
   - travis-tool.sh install_deps
+  - travis-tool.sh install_github mrc-ide/context
 
 test_script:
   - travis-tool.sh run_tests

--- a/tests/testthat/helper-queuer.R
+++ b/tests/testthat/helper-queuer.R
@@ -1,3 +1,4 @@
 skip_if_not_using_local_queue <- function() {
-  testthat::skip("not using local queue")
+  skip_on_cran()
+  skip_if_not_installed("thor")
 }

--- a/tests/testthat/helper-queuer.R
+++ b/tests/testthat/helper-queuer.R
@@ -1,0 +1,3 @@
+skip_if_not_using_local_queue <- function() {
+  testthat::skip("not using local queue")
+}

--- a/tests/testthat/test-bulk.R
+++ b/tests/testthat/test-bulk.R
@@ -54,7 +54,7 @@ test_that("named group", {
 })
 
 test_that("named lapply", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile())
   obj <- queue_local(ctx)
   bundle <- obj$lapply(setNames(as.list(1:3), letters[1:3]), I)
@@ -72,7 +72,7 @@ test_that("named lapply", {
 })
 
 test_that("$enqueue_bulk", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile())
   obj <- queue_local(ctx)
   bundle <- obj$enqueue_bulk(1:3, quote(I))
@@ -81,7 +81,7 @@ test_that("$enqueue_bulk", {
 })
 
 test_that("exotic functions", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   Sys.setenv(R_TESTS = "")
 
   ctx <- context::context_save(tempfile(), storage_type = "environment")
@@ -113,7 +113,7 @@ test_that("sanity checking", {
 })
 
 test_that("mapply", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   obj <- queue_local(ctx)
 
@@ -144,7 +144,7 @@ test_that("mapply", {
 })
 
 test_that("mapply - recycle", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   obj <- queue_local(ctx)
   grp <- obj$mapply(rep, 1:4, 1)

--- a/tests/testthat/test-fifo.R
+++ b/tests/testthat/test-fifo.R
@@ -1,9 +1,8 @@
 context("fifo")
 
-test_that("seagull", {
-  skip_if_not_installed("seagull")
-  q <- fifo_seagull(storr::storr_environment(), "queue", "objects",
-                    tempfile(), 1)
+test_that("fifo_thor", {
+  skip_if_not_installed("thor")
+  q <- fifo_thor(tempfile())
   expect_equal(q$read(), character(0))
   expect_null(q$pop())
 

--- a/tests/testthat/test-queue-base.R
+++ b/tests/testthat/test-queue-base.R
@@ -17,7 +17,8 @@ test_that("empty", {
   ## Behaviour of missing tasks is tested elsewhere
   expect_is(obj$task_get(ids::random_id(), FALSE), "queuer_task")
 
-  expect_error(obj$task_result(ids::random_id()), "unfetchable: MISSING")
+  expect_error(obj$task_result(ids::random_id()), "unfetchable: MISSING",
+               class = "UnfetchableTask")
   expect_false(obj$task_delete(ids::random_id()))
 
   expect_equal(obj$task_bundle_list(), character(0))
@@ -26,7 +27,7 @@ test_that("empty", {
   expect_equal(nrow(info), 0)
 
   expect_error(obj$task_bundle_get(ids::adjective_animal()),
-               "not found")
+               "not found", class = "KeyError")
 })
 
 test_that("enqueue", {

--- a/tests/testthat/test-queue-local.R
+++ b/tests/testthat/test-queue-local.R
@@ -1,7 +1,7 @@
 context("queue_local")
 
 test_that("empty queue", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile())
   on.exit(unlink(ctx$db$destroy()))
   obj <- queue_local(ctx)
@@ -16,7 +16,7 @@ test_that("empty queue", {
 })
 
 test_that("enqueue", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile())
   on.exit(unlink(ctx$db$destroy()))
   log_path <- "logs"
@@ -85,7 +85,7 @@ test_that("enqueue", {
 })
 
 test_that("environment storage", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   on.exit(unlink(ctx$db$destroy()))
 
@@ -108,7 +108,7 @@ test_that("environment storage", {
 })
 
 test_that("initialise later", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   on.exit(unlink(ctx$db$destroy()))
   obj <- queue_local(ctx, initialize = FALSE)
@@ -122,7 +122,7 @@ test_that("initialise later", {
 })
 
 test_that("unsubmit", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   on.exit(unlink(ctx$db$destroy()))
 
@@ -142,7 +142,7 @@ test_that("unsubmit", {
 })
 
 test_that("submit_or_delete", {
-  skip_if_not_installed("seagull")
+  skip_if_not_using_local_queue()
   ctx <- context::context_save(tempfile(), storage_type = "environment")
   on.exit(unlink(ctx$db$destroy()))
 

--- a/tests/testthat/test-tasks.R
+++ b/tests/testthat/test-tasks.R
@@ -14,7 +14,7 @@ test_that("basic", {
   expect_equal(t$status(), "PENDING")
   expect_equal(t$expr(), quote(sin(1)))
   expect_equal(t$context_id(), ctx$id)
-  expect_error(t$result(), "is unfetchable")
+  expect_error(t$result(), "is unfetchable", class = "UnfetchableTask")
   expect_is(t$result(TRUE), "UnfetchableTask")
 
   ## expect_error(t$log(), "No log for")
@@ -54,9 +54,9 @@ test_that("missing task", {
 
   t <- queuer_task(ids::random_id(), ctx, FALSE)
   expect_equal(t$context_id(), NA_character_)
-  expect_error(t$expr(), "not found")
+  expect_error(t$expr(), "not found", class = "KeyError")
   expect_equal(t$status(), "MISSING")
-  expect_error(t$result(), "unfetchable: MISSING")
+  expect_error(t$result(), "unfetchable: MISSING", class = "UnfetchableTask")
   expect_is(t$result(TRUE), "UnfetchableTask")
 })
 


### PR DESCRIPTION
This PR will tidy up the package to get it passing again on appveyor.

The principle change is that the proof-of-concept queue changes its implementation from being based on file locking with seagull (which will probably never go to cran as it proved not to be super reliable) to use thor (which is on cran since March).

Other changes just tighten up the QA checking, updates to deal with changes in testthat, remotes and appveyor.